### PR TITLE
Fix rotation by removing last commit

### DIFF
--- a/jquery.ui.rotatable.js
+++ b/jquery.ui.rotatable.js
@@ -4,7 +4,7 @@ $.widget("ui.rotatable", $.ui.mouse, {
 	
 	options: {
 		handle: false,
-        angle: false
+        angle: 0
 	},
 	
 	handle: function(handle) {
@@ -34,11 +34,8 @@ $.widget("ui.rotatable", $.ui.mouse, {
 		handle.draggable({ helper: 'clone', start: dragStart });
 		handle.on('mousedown', startRotate);
 		handle.appendTo(this.element);
-        if(this.options.angle != false)
-        {
-            this.element.data('angle', this.options.angle);
-            performRotation(this.element, this.options.angle);
-        }
+		this.element.data('angle', this.options.angle);
+		performRotation(this.element, this.options.angle);
 	},
 
     _destroy: function() {


### PR DESCRIPTION
@awers' commit broke the plugin: The condition on angle value was never true if no angle was specified at initialization
