### PR TITLE
Snap to rotation-degrees

### DIFF
--- a/jquery.ui.rotatable.js
+++ b/jquery.ui.rotatable.js
@@ -5,6 +5,9 @@ $.widget("ui.rotatable", $.ui.mouse, {
     options: {
         handle: false,
         angle: false,
+        snap: false,
+        steps: 22.5,
+
         
         rotationCenterX: false, 
         rotationCenterY: false,
@@ -59,12 +62,12 @@ $.widget("ui.rotatable", $.ui.mouse, {
             rotateElement: $.proxy(this.rotateElement, this),
             startRotate: $.proxy(this.startRotate, this),
             stopRotate: $.proxy(this.stopRotate, this),
-			wheelRotate: $.proxy(this.wheelRotate, this)
+            wheelRotate: $.proxy(this.wheelRotate, this)
         };
 
-		this.element.bind('wheel', this.listeners.wheelRotate);
+        this.element.bind('wheel', this.listeners.wheelRotate);
 
-		handle.draggable({ helper: 'clone', start: this.dragStart, handle: handle });
+        handle.draggable({ helper: 'clone', start: this.dragStart, handle: handle });
         handle.bind('mousedown', this.listeners.startRotate);
         handle.appendTo(this.element);
         
@@ -147,24 +150,13 @@ $.widget("ui.rotatable", $.ui.mouse, {
             return false;
         }
         
-        var center = this.getElementCenter();
-        
-        var xFromCenter = event.pageX - center[0];
-        var yFromCenter = event.pageY - center[1];
-        var mouseAngle = Math.atan2(yFromCenter, xFromCenter);
-        var rotateAngle = mouseAngle - this.mouseStartAngle + this.elementStartAngle;
-        
-        if (event.shiftKey) {
-			var predefinedAngle = 15 / 180 * Math.PI;
-			if (rotateAngle < 0)
-				predefinedAngle *= -1;
-			rotateAngle -= (rotateAngle + predefinedAngle / 2) % (predefinedAngle) - predefinedAngle / 2;
-		}
+        var rotateAngle = this.getRotateAngle();
 
         this.performRotation(rotateAngle);
         var previousRotateAngle = this.elementCurrentAngle;
         this.elementCurrentAngle = rotateAngle;
 
+        // Plugins callbacks need to be called first.
         this._propagate("rotate", event);
 
         if (previousRotateAngle != rotateAngle) {
@@ -191,13 +183,39 @@ $.widget("ui.rotatable", $.ui.mouse, {
         setTimeout( function() { this.element = false; }, 10 );
         return false;
     },
-	
-	wheelRotate: function(event) {
-		var angle = Math.round(event.originalEvent.deltaY/10) * Math.PI/180;
-		angle = this.elementCurrentAngle + angle;
-		this.angle(angle);
-		this._trigger("rotate", event, this.ui());
-	},
+
+    getRotateAngle: function(){
+
+        var center = this.getElementCenter();
+        
+        var xFromCenter = event.pageX - center[0];
+        var yFromCenter = event.pageY - center[1];
+        var mouseAngle = Math.atan2(yFromCenter, xFromCenter);
+        var rotateAngle = mouseAngle - this.mouseStartAngle + this.elementStartAngle;
+
+        if( this.options.snap ){
+
+            //convert radians to degrees
+            var rotateDegrees = ( ( rotateAngle / Math.PI ) * 180 ) + 180;
+
+            //round to nearest step
+            rotateDegrees = Math.round( rotateDegrees / this.options.steps ) * this.options.steps;
+
+            //convert it back to radians
+            rotateAngle = ( rotateDegrees * Math.PI ) / 180;
+
+        }
+
+        return rotateAngle;
+
+    },
+    
+    wheelRotate: function(event) {
+        var angle = Math.round(event.originalEvent.deltaY/10) * Math.PI/180;
+        angle = this.elementCurrentAngle + angle;
+        this.angle(angle);
+        this._trigger("rotate", event, this.ui());
+    },
 
     _propagate: function(n, event) {
         $.ui.plugin.call(this, n, [event, this.ui()]);
@@ -208,7 +226,7 @@ $.widget("ui.rotatable", $.ui.mouse, {
 
     ui: function() {
         return {
-			api:this,
+            api:this,
             element: this.element,
             angle: {
                 start: this.elementStartAngle,


### PR DESCRIPTION
i've added a 'snap to degrees' option, so you can rotate more accurately if you need *exactly* 45 degrees, for instance


You can add snap = true and the amount of steps in degrees along the options for your plugin.
Default in step-size is 22.5, because it equals frequent degrees you'd want to use ( 45, 90, 180 ), plus it kinda 'felt right'.


Haven't minified it, though.