### PR TITLE
Add widget event prefix

### DIFF
--- a/jquery.ui.rotatable.js
+++ b/jquery.ui.rotatable.js
@@ -1,6 +1,7 @@
 (function( $, undefined ) {
 
 $.widget("ui.rotatable", $.ui.mouse, {
+	widgetEventPrefix: "rotate",
 
     options: {
         handle: false,


### PR DESCRIPTION
I think it would be nice if rotatable trigger event **rotatestart rotate rotatestop** instead of **rotatablerotatestart rotatablerotate rotatablerotatestop**
