### PR TITLE
Allow initial degrees value to work correctly

### DIFF
--- a/jquery.ui.rotatable.js
+++ b/jquery.ui.rotatable.js
@@ -277,7 +277,9 @@
       if (this.options.degrees) {
         this.elementCurrentAngle = this._angleInRadians(this.options.degrees)
       }
-      this.elementCurrentAngle = this.options.radians || this.options.angle || 0
+      else {
+        this.elementCurrentAngle = this.options.radians || this.options.angle || 0
+      }
       this._performRotation(this.elementCurrentAngle)
     },
 


### PR DESCRIPTION
Setting the `degrees` value doesn't work, as it is overridden by the next line in 

https://github.com/godswearhats/jquery-ui-rotatable/blob/01d94c1b6ead6f18f9d24be97d48f6bd2772ee9d/jquery.ui.rotatable.js#L280