### PR TITLE
Check for disabled in mouse wheel listener

### DIFF
--- a/jquery.ui.rotatable.js
+++ b/jquery.ui.rotatable.js
@@ -153,6 +153,7 @@
       if (!this.element || this.element.disabled || this.options.disabled) {
         return
       }
+      event.preventDefault()
       var angle = this._angleInRadians(Math.round(event.originalEvent.deltaY / 10))
       if (this.options.snap || event.shiftKey) {
         angle = this._calculateSnap(angle)

--- a/jquery.ui.rotatable.js
+++ b/jquery.ui.rotatable.js
@@ -150,6 +150,9 @@
 
     // listener for mousewheel rotation
     wheelRotate: function (event) {
+      if (!this.element || this.element.disabled || this.options.disabled) {
+        return
+      }
       var angle = this._angleInRadians(Math.round(event.originalEvent.deltaY / 10))
       if (this.options.snap || event.shiftKey) {
         angle = this._calculateSnap(angle)


### PR DESCRIPTION
Hi,

great plugin! If you like, this PR contains two very small adjustments for the mouse wheel listener:

1. Even elements with disabled rotatability ( `$('#target').rotatable('disable')` ) can still be rotated by using the mouse wheel. Now a check is added in order to prevent the rotation of disabled elements.
2. event.preventDefault() is added in order to avoid scrolling the page when rotating elements using the mouse wheel.

If something is wrong with this PR or there is no need for it, just tell me please. :-)